### PR TITLE
Fix of issue #36

### DIFF
--- a/src/main/java/bdsup2sub/core/Core.java
+++ b/src/main/java/bdsup2sub/core/Core.java
@@ -15,32 +15,46 @@
  */
 package bdsup2sub.core;
 
+import static bdsup2sub.core.Constants.*;
+import static bdsup2sub.utils.SubtitleUtils.*;
+import static bdsup2sub.utils.TimeUtils.*;
+import static com.mortennobel.imagescaling.ResampleFilters.*;
+import java.awt.image.BufferedImage;
+import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.swing.*;
 import bdsup2sub.bitmap.Bitmap;
 import bdsup2sub.bitmap.BitmapWithPalette;
 import bdsup2sub.bitmap.ErasePatch;
 import bdsup2sub.bitmap.Palette;
 import bdsup2sub.gui.support.Progress;
-import bdsup2sub.supstream.*;
+import bdsup2sub.supstream.SubPicture;
+import bdsup2sub.supstream.SubtitleStream;
 import bdsup2sub.supstream.bd.SupBD;
 import bdsup2sub.supstream.bd.SupBDWriter;
 import bdsup2sub.supstream.bdnxml.SupXml;
-import bdsup2sub.supstream.dvd.*;
+import bdsup2sub.supstream.dvd.DvdSubtitleStream;
+import bdsup2sub.supstream.dvd.IfoWriter;
+import bdsup2sub.supstream.dvd.SubDvd;
+import bdsup2sub.supstream.dvd.SubDvdWriter;
+import bdsup2sub.supstream.dvd.SubPictureDVD;
+import bdsup2sub.supstream.dvd.SupDvd;
+import bdsup2sub.supstream.dvd.SupDvdUtil;
+import bdsup2sub.supstream.dvd.SupDvdWriter;
 import bdsup2sub.supstream.hd.SupHD;
 import bdsup2sub.tools.EnhancedPngEncoder;
 import bdsup2sub.utils.FilenameUtils;
 import bdsup2sub.utils.SubtitleUtils;
 import bdsup2sub.utils.ToolBox;
 import com.mortennobel.imagescaling.ResampleFilter;
-
-import javax.swing.*;
-import java.awt.image.BufferedImage;
-import java.io.*;
-import java.util.*;
-
-import static bdsup2sub.core.Constants.*;
-import static bdsup2sub.utils.SubtitleUtils.getResolutionForDimension;
-import static bdsup2sub.utils.TimeUtils.ptsToTimeStr;
-import static com.mortennobel.imagescaling.ResampleFilters.*;
 
 /**
  * This class contains the core functionality of BDSup2Sub.<br>
@@ -571,7 +585,7 @@ public class Core extends Thread {
             substreamDvd = subDVD;
         } else {
             // SUP/IFO
-            if (FilenameUtils.getExtension(fname).equals("ifo")) {
+            if (FilenameUtils.getExtension(fname).equalsIgnoreCase("ifo") ) {
                 fnI = fname;
                 fnS = FilenameUtils.removeExtension(fname) + ".sup";
             } else {


### PR DESCRIPTION
When loading the subpicture stream from a pair of SUP/IFO files, BDSup2Sub now ignores the casing of the "IFO" extension so that it doesn't display an error message about the non-existent IFO file.
