### PR TITLE
Bugfix in the code for exporting in the BDN format

### DIFF
--- a/src/main/java/bdsup2sub/supstream/bdnxml/SupXml.java
+++ b/src/main/java/bdsup2sub/supstream/bdnxml/SupXml.java
@@ -397,7 +397,7 @@ public class SupXml implements SubtitleStream {
      * @return PNG name
      */
     public static String getPNGname(String fn, int idx) {
-        return FilenameUtils.removeExtension(fn) + "_" + ToolBox.leftZeroPad(idx, 4) + ".png";
+        return fn + "_" + ToolBox.leftZeroPad(idx, 4) + ".png";
     }
 
     /**


### PR DESCRIPTION
When generating names for the PNG files an extension was removed twice from the name of the XML file, so the names of the PNG files were not as expected if the name of the XML file had multiple extensions.
